### PR TITLE
#8 Specify mdanalysis version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 #
-MDAnalysis
+MDAnalysis>=0.17.0
 pandas
 numpy
 matplotlib


### PR DESCRIPTION
Add specification for MDAnalysis package to maintain Python 3.4+ compatibility.
This fixes #8.