### PR TITLE
More sensible defaults to compile_tprs

### DIFF
--- a/paratemp/__init__.py
+++ b/paratemp/__init__.py
@@ -29,13 +29,18 @@ import sys
 from . import para_temp_setup
 from .tools import copy_no_overwrite, cd, get_temperatures
 from . import coordinate_analysis
+from .coordinate_analysis import Universe
 from . import re_universe
+from .re_universe import REUniverse
 from ._version import get_versions
+
+del absolute_import
 
 if sys.version_info.major == 2:
     # These (at this point) require python 2 because of gromacs (gromacswrapper)
     from . import energy_histo
     from . import energy_bin_analysis
+del sys
 
 
 __version__ = get_versions()['version']

--- a/paratemp/para_temp_setup.py
+++ b/paratemp/para_temp_setup.py
@@ -43,16 +43,21 @@ from .tools import cd
 from ._version import get_versions
 
 
-def compile_tprs(template='templatemdp.txt', start_temp=205., number=16,
-                 scaling_exponent=0.025, base_name='npt',
+def compile_tprs(start_temp, scaling_exponent,
+                 template='templatemdp.txt', number=16,
+                 base_name='npt',
                  topology='../*top', multi_structure=False,
                  structure='../*gro', index='../index.ndx',
                  temps_file='temperatures.dat', maxwarn='0',
-                 grompp_exe='gmx_mpi grompp'):
+                 grompp_exe='gmx grompp'):
     """
     Compile TPR files for multi-temperature run with GROMACS
 
-    This works in the current directory.
+    This works in the current directory. The defaults make the most sense if
+    the current directory is a sub-directory of some main folder that
+    includes the starting geometry and topology information. In many cases,
+    this folder is named 'TOPO' is just used to contain the topology and MDP
+    files and the GROMPP information and logs.
 
     With exponential temperature spacing, this is mostly useful for compiling
     TPR files for replica exchange dynamics.
@@ -62,14 +67,19 @@ def compile_tprs(template='templatemdp.txt', start_temp=205., number=16,
     'temperatures.dat'). These are the stdout and stderr from grompp and the
     temperatures of the simulations, respectively.
 
-    :param str template: name of template mdp file
-    :param float start_temp: starting (lowest) temperature
+    :param float start_temp: starting (lowest) temperature, in Kelvin
+    :param float scaling_exponent: exponent by which to scale the temperatures.
+        The temperature will be :math:`T_0 e^{j s}` where :math:`T_0` is the
+        ``start_temp``, :math:`s` is the ``scaling_exponent``, and :math:`j`
+        is the index of the replica between 0 and (``number``-1).
+    :param str template: name of template mdp file with 'TempGoesHere' where
+        the temperature of the replica should be placed.
     :param int number: number of replicas/walkers
-    :param float scaling_exponent: exponent by which to scale the temperatures
     :param str base_name: base name for output mdp and tpr files
-    :param str topology: name of topology file
+    :param str topology: name of topology ('.top') file
     :param bool multi_structure: multiple (different) structure files
-        (uses glob expansion on the input structure base name)
+        (uses glob expansion on the input structure base name by adding
+        '*.gro' to the ``structure`` keyword argument)
     :param str structure: (base) name of structure file(s)
     :param str index: name of index file
     :param str temps_file: name of file in which to store temperatures

--- a/tests/test_para_temp_setup.py
+++ b/tests/test_para_temp_setup.py
@@ -75,7 +75,8 @@ class TestCompileTPRs(object):
         dir_topo = pt_dir_blank.mkdir('TOPO')
         number = 2
         with dir_topo.as_cwd():
-            compile_tprs(start_temp=298, number=number,
+            compile_tprs(start_temp=298, scaling_exponent=0.025,
+                         number=number,
                          template='../'+n_template,
                          structure='../'+n_gro,
                          base_name='nvt',
@@ -92,7 +93,8 @@ class TestCompileTPRs(object):
         dir_topo = pt_dir_blank.mkdir('TOPO')
         number = 2
         with dir_topo.as_cwd():
-            compile_tprs(start_temp=298, number=number,
+            compile_tprs(start_temp=298,  scaling_exponent=0.025,
+                         number=number,
                          template='../'+n_template,
                          multi_structure=True,
                          structure='../PT-out',
@@ -110,7 +112,8 @@ class TestCompileTPRs(object):
         number = 2
         with dir_topo.as_cwd(), pytest.raises(
                 OSError, match='Incorrect number of structure files found'):
-            compile_tprs(start_temp=298, number=number,
+            compile_tprs(start_temp=298,  scaling_exponent=0.025,
+                         number=number,
                          template='../'+n_template,
                          multi_structure=True,
                          structure='../',
@@ -118,14 +121,16 @@ class TestCompileTPRs(object):
                          grompp_exe=grompp)
         with dir_topo.as_cwd(), pytest.raises(
                 OSError, match='No structure file found'):
-            compile_tprs(start_temp=298, number=number,
+            compile_tprs(start_temp=298,  scaling_exponent=0.025,
+                         number=number,
                          template='../'+n_template,
                          structure='../not-here.gro',
                          base_name='nvt',
                          grompp_exe=grompp)
         with dir_topo.as_cwd(), pytest.raises(
                 OSError, match='No topology file found'):
-            compile_tprs(start_temp=298, number=number,
+            compile_tprs(start_temp=298,  scaling_exponent=0.025,
+                         number=number,
                          template='../'+n_template,
                          structure='../'+n_gro,
                          topology='../not-here.top',
@@ -137,7 +142,8 @@ class TestCompileTPRs(object):
         dir_topo = pt_dir_blank.mkdir('TOPO')
         number = 2
         with dir_topo.as_cwd(), pytest.raises(RuntimeError):
-            compile_tprs(start_temp=298, number=number,
+            compile_tprs(start_temp=298,  scaling_exponent=0.025,
+                         number=number,
                          template='../'+n_template,
                          structure='../*top',
                          base_name='nvt',
@@ -150,7 +156,8 @@ class TestCompileTPRs(object):
         number = 2
         with dir_topo.as_cwd(), pytest.warns(
                 UserWarning, match=r'Found \d+ structure files'):
-            compile_tprs(start_temp=298, number=number,
+            compile_tprs(start_temp=298,  scaling_exponent=0.025,
+                         number=number,
                          template='../'+n_template,
                          structure='../*.gro',
                          base_name='nvt',


### PR DESCRIPTION
Fixes #16. 

No default starting temp or scaling exponent.
Expanded the docstring a bit, too.