### PR TITLE
Automatically save and read data when calculating distances

### DIFF
--- a/paratemp/coordinate_analysis.py
+++ b/paratemp/coordinate_analysis.py
@@ -160,6 +160,7 @@ class Universe(MDa.Universe):
                     if self._verbosity:
                         print('No data to read in '
                               '{}[{}]'.format(filename, time))
+                    return
         for key in keys_to_read:
             self._data[key] = read_df[key]
 

--- a/paratemp/coordinate_analysis.py
+++ b/paratemp/coordinate_analysis.py
@@ -164,6 +164,7 @@ class Universe(MDa.Universe):
             self._data[key] = read_df[key]
 
     def calculate_distances(self, recalculate=False, ignore_file_change=False,
+                            read_data=True, save_data=True,
                             *args, **kwargs):
         """
         Calculate distances by iterating through the trajectory
@@ -180,6 +181,13 @@ class Universe(MDa.Universe):
             the file has changed will be printed.
             If False, if the length of the trajectory has changed,
             FileChangedError will be raised.
+        :param bool read_data: Default: True.
+            If True, :func:`read_data` will be used to read any data in the
+            default file with `ignore_no_data=True`.
+        :param bool save_data: Default: True.
+            If True, :func:`save_data` will be used to save the calculated
+            distances to the default file.
+            Nothing will be saved if there is nothing new to calculate.
         :param args:
         :param kwargs:
         :return: None
@@ -270,6 +278,8 @@ class Universe(MDa.Universe):
                                          result=dists[i])
         for i, column in enumerate(column_names):
             self._data[column] = dists[:, i]
+        if save_data:
+            self.save_data()
 
     def calculate_dihedrals(self, *args, **kwargs):
         """"""

--- a/paratemp/coordinate_analysis.py
+++ b/paratemp/coordinate_analysis.py
@@ -198,6 +198,11 @@ class Universe(MDa.Universe):
         # TODO document this function
         # TODO find a way to take keyword type args with non-valid python
         # identifiers (e.g., "O-O").
+        if read_data:
+            v = self._verbosity
+            self._verbosity = False
+            self.read_data(ignore_no_data=True)
+            self._verbosity = v
         # Make empty atom selections to be appended to:
         first_group = self.select_atoms('protein and not protein')
         second_group = self.select_atoms('protein and not protein')

--- a/paratemp/coordinate_analysis.py
+++ b/paratemp/coordinate_analysis.py
@@ -112,7 +112,7 @@ class Universe(MDa.Universe):
             if overwrite or ('/'+time not in store.keys()):
                 store[time] = self._data
             else:
-                store_cols = store.get_node(time).axis0.read()
+                store_cols = store.get_node(time).axis0.read().astype(str)
                 set_diff_cols = set(self._data.columns).difference(store_cols)
                 if not set_diff_cols:
                     if self._verbosity:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ matplotlib
 panedr
 py
 gromacswrapper
+tables
 typing
 scipy
 six

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
         'matplotlib',
         'panedr',
         'gromacswrapper',
+        'tables',
         'typing',
         'scipy',
         'six',

--- a/tests/test_coordinate_analysis.py
+++ b/tests/test_coordinate_analysis.py
@@ -254,6 +254,20 @@ class TestXTCUniverse(object):
             f_name=f_name, time=time)
         assert np.allclose(df, univ.data)
 
+    def test_calculate_distances_read(self, univ_w_a, tmpdir, capsys):
+        """
+        :type univ_w_a: paratemp.Universe
+        """
+        with tmpdir.as_cwd():
+            univ_w_a.save_data()
+            capsys.readouterr()
+            univ_w_a._data = univ_w_a._init_dataframe()
+            univ_w_a.calculate_distances(a='4 5')
+            out, err = capsys.readouterr()
+        assert out == 'Nothing (new) to calculate here.\n'
+
+
+
 # TODO add further Universe tests
 #       ignore_file_change=True
 #       fes_2d

--- a/tests/test_coordinate_analysis.py
+++ b/tests/test_coordinate_analysis.py
@@ -238,6 +238,21 @@ class TestXTCUniverse(object):
             univ.read_data()
         assert (univ_w_a.data == univ.data).all().all()
 
+    def test_read_data_no_data(self, univ, tmpdir, capsys):
+        """
+        :type univ: paratemp.Universe
+        """
+        time = 'time_' + str(int(univ._last_time / 1000)) + 'ns'
+        f_name = univ.trajectory.filename.replace('xtc', 'h5')
+        with tmpdir.as_cwd():
+            with pytest.raises(IOError, message='This data does not exist!\n'
+                                                '{}[{}]\n'.format(f_name,
+                                                                  time)):
+                univ.read_data()
+            univ.read_data(ignore_no_data=True)
+            out, err = capsys.readouterr()
+        assert out == 'No data to read in {}[{}]\n'.format(f_name, time)
+
     def test_calculate_distances_save(self, univ, tmpdir, capsys):
         """
         :type univ: paratemp.Universe

--- a/tests/test_coordinate_analysis.py
+++ b/tests/test_coordinate_analysis.py
@@ -106,19 +106,23 @@ class TestXTCUniverse(object):
         return np.load('tests/ref-data/spc2-fes1d-bins-20.npy')
 
     def test_distance_str(self, univ, ref_a_dists):
-        univ.calculate_distances(a='4 5')
+        univ.calculate_distances(a='4 5',
+                                 read_data=False, save_data=False)
         assert np.isclose(ref_a_dists, univ.data['a']).all()
 
     def test_distance_list_int(self, univ, ref_a_dists):
-        univ.calculate_distances(a=[4, 5])
+        univ.calculate_distances(a=[4, 5],
+                                 read_data=False, save_data=False)
         assert np.isclose(ref_a_dists, univ.data['a']).all()
 
     def test_distance_list_str(self, univ, ref_a_dists):
-        univ.calculate_distances(a=['4', '5'])
+        univ.calculate_distances(a=['4', '5'],
+                                 read_data=False, save_data=False)
         assert np.isclose(ref_a_dists, univ.data['a']).all()
 
     def test_calculate_distances_no_recalc(self, univ_w_a, capsys):
-        univ_w_a.calculate_distances(a=[4, 5])
+        univ_w_a.calculate_distances(a=[4, 5],
+                                     read_data=False, save_data=False)
         out, err = capsys.readouterr()
         assert out == 'Nothing (new) to calculate here.\n'
 
@@ -126,11 +130,13 @@ class TestXTCUniverse(object):
         """
         :type univ_w_a: paratemp.coordinate_analysis.Universe
         """
-        univ_w_a.calculate_distances(a='5 5', recalculate=True)
+        univ_w_a.calculate_distances(a='5 5', recalculate=True,
+                                     read_data=False, save_data=False)
         assert (np.array([0., 0.]) == univ_w_a.data['a']).all()
 
     def test_distance_pbc(self, univ_pbc, ref_a_pbc_dists):
-        univ_pbc.calculate_distances(a='4 5')
+        univ_pbc.calculate_distances(a='4 5',
+                                     read_data=False, save_data=False)
         assert np.isclose(ref_a_pbc_dists['a'], univ_pbc.data['a']).all()
 
     def test_calc_fes_1d(self, univ_w_a, ref_delta_g, ref_bins, ref_delta_g_20,

--- a/tests/test_coordinate_analysis.py
+++ b/tests/test_coordinate_analysis.py
@@ -186,15 +186,28 @@ class TestXTCUniverse(object):
         univ._last_time = 5.1e12
         assert univ.final_time_str == '5100ms'
 
-    def test_save_data(self, univ_w_a, tmpdir):
+    def test_save_data(self, univ_w_a, tmpdir, capsys):
         time = 'time_' + str(int(univ_w_a._last_time / 1000)) + 'ns'
         f_name = univ_w_a.trajectory.filename.replace('xtc', 'h5')
         with tmpdir.as_cwd():
             univ_w_a.save_data()
+            out, err = capsys.readouterr()
             assert tmpdir.join(f_name).exists()
             with pd.HDFStore(f_name) as store:
                 df = store[time]
+        assert out == 'Saved data to t-spc2-traj.h5[time_0ns]\n'
         assert np.allclose(df, univ_w_a.data)
+
+    def test_read_data(self, univ, univ_w_a, tmpdir, capsys):
+        """
+        :type univ_w_a: paratemp.Universe
+        :type univ: paratemp.Universe
+        """
+        with tmpdir.as_cwd():
+            univ_w_a.save_data()
+            capsys.readouterr()  # just so it doesn't print
+            univ.read_data()
+        assert (univ_w_a.data == univ.data).all().all()
 
 # TODO add further Universe tests
 #       ignore_file_change=True

--- a/tests/test_coordinate_analysis.py
+++ b/tests/test_coordinate_analysis.py
@@ -195,8 +195,36 @@ class TestXTCUniverse(object):
             assert tmpdir.join(f_name).exists()
             with pd.HDFStore(f_name) as store:
                 df = store[time]
-        assert out == 'Saved data to t-spc2-traj.h5[time_0ns]\n'
+        assert out == 'Saved data to {f_name}[{time}]\n'.format(
+            f_name=f_name, time=time)
         assert np.allclose(df, univ_w_a.data)
+
+    def test_save_data_no_new(self, univ_w_a, tmpdir, capsys):
+        time = 'time_' + str(int(univ_w_a._last_time / 1000)) + 'ns'
+        f_name = univ_w_a.trajectory.filename.replace('xtc', 'h5')
+        with tmpdir.as_cwd():
+            univ_w_a.save_data()
+            capsys.readouterr()
+            univ_w_a.save_data()
+            out, err = capsys.readouterr()
+            assert tmpdir.join(f_name).exists()
+            with pd.HDFStore(f_name) as store:
+                df = store[time]
+        assert out == 'No data added to {f_name}[{time}]\n'.format(
+            f_name=f_name, time=time)
+        assert np.allclose(df, univ_w_a.data)
+
+    def test_save_data_add_new(self, univ, univ_w_a, tmpdir, capsys):
+        time = 'time_' + str(int(univ_w_a._last_time / 1000)) + 'ns'
+        f_name = univ_w_a.trajectory.filename.replace('xtc', 'h5')
+        with tmpdir.as_cwd():
+            univ_w_a.save_data()
+            capsys.readouterr()
+            univ.calculate_distances(b='4 5')
+            univ.save_data()
+            out, err = capsys.readouterr()
+        assert out == 'Saved data to {f_name}[{time}]\n'.format(
+            f_name=f_name, time=time)
 
     def test_read_data(self, univ, univ_w_a, tmpdir, capsys):
         """


### PR DESCRIPTION
Fixes #27. 

In the future, it could be good to make these defaults settable, but doing this seems to be a more logical default behavior.

Added tests for save and read data.
Also, copy universe data for test fixtures to a temporary directory.

Also, likely because of changes to pandas (or just because I've never testing these features before), tables now needs to be specified as a dependency here to get read_data and save_data to work. I was getting some odd errors with the tests just freezing or hitting infinite loops, but specifying the dependency seems to fix those.

Finally, there was a small issue in Python 3.6 with str vs. bytes objects as column names when reading a HDFStore file.