### PR TITLE
#35 GromacsWrapper ≥ 0.7 supports Python 3.4+

### DIFF
--- a/paratemp/__init__.py
+++ b/paratemp/__init__.py
@@ -24,8 +24,6 @@
 
 from __future__ import absolute_import
 
-import sys
-
 from . import para_temp_setup
 from .tools import copy_no_overwrite, cd, get_temperatures
 from . import coordinate_analysis
@@ -36,12 +34,6 @@ from ._version import get_versions
 from . import plotting
 
 del absolute_import
-
-if sys.version_info.major == 2:
-    # These (at this point) require python 2 because of gromacs (gromacswrapper)
-    from . import energy_histo
-    from . import energy_bin_analysis
-del sys
 
 
 __version__ = get_versions()['version']

--- a/paratemp/coordinate_analysis.py
+++ b/paratemp/coordinate_analysis.py
@@ -410,7 +410,7 @@ class Universe(MDa.Universe):
         :param bins: Default: None. The bins argument to be passed to
             np.histogram
 
-        :param str xlabel: Default: 'distance / $\mathrm{\AA}$'. The label for
+        :param str xlabel: Default: 'distance / $\\mathrm{\\AA}$'. The label for
             the x axis.
 
         :type ax: matplotlib.axes.Axes
@@ -935,7 +935,7 @@ class Taddol(Universe):
                 **kwargs)
         ax.legend()
         ax.set_xlabel('time / ps')
-        ax.set_ylabel('distance / $\mathrm{\AA}$')
+        ax.set_ylabel(r'distance / $\mathrm{\AA}$')
         if save:
             fig.savefig(save_base_name + save_format)
         if display:
@@ -1194,7 +1194,7 @@ def make_plot_taddol_ox_dists(data, save=False, save_format='pdf',
     axes.plot(data[:, 0], data[:, 3], label='O(r)-Cy')
     axes.legend()
     axes.set_xlabel('time / ps')
-    axes.set_ylabel('distance / $\mathrm{\AA}$')
+    axes.set_ylabel(r'distance / $\mathrm{\AA}$')
     if save:
         fig.savefig(save_base_name+save_format)
     if display:
@@ -1279,7 +1279,7 @@ def make_taddol_pi_dist_array(dists, save=False, save_format='pdf',
     """Plot array of pi distances in TADDOL trajectory"""
     fig = plot_dist_array(dists)
     [ax.get_xaxis().set_ticks([]) for ax in fig.axes]
-    fig.text(0.05, 0.585, 'distance / $\mathrm{\AA}$', ha='center',
+    fig.text(0.05, 0.585, r'distance / $\mathrm{\AA}$', ha='center',
              rotation='vertical')
     fig.text(0.513, 0.08, 'time', ha='center')
     if save:

--- a/paratemp/energy_histo.py
+++ b/paratemp/energy_histo.py
@@ -36,12 +36,7 @@ import numpy as np
 import pandas as pd
 
 from .tools import all_elements_same
-
-__version__ = '0.0.2'
-
-# todo define a set of run data as a class
-# possibly as a class of mdanalysis universes, but not sure how to work with
-# replicas vs. walkers there.
+from . import __version__
 
 # TODO update docstrings to PEP specs
 # (one brief description line, blank line, longer description/guidelines)

--- a/paratemp/plotting.py
+++ b/paratemp/plotting.py
@@ -59,7 +59,7 @@ def fes_1d(x, temp, ax=None, bins=None,
     :param bins: Default: None. The bins argument to be passed to
         np.histogram
 
-    :param str xlabel: Default: 'distance / $\mathrm{\AA}$'. The label for
+    :param str xlabel: Default: 'distance / $\\mathrm{\\AA}$'. The label for
         the x axis.
 
     :type ax: matplotlib.axes.Axes

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ numpy
 matplotlib
 panedr
 py
-gromacswrapper
+gromacswrapper>=0.7
 tables
 typing
 scipy

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         'numpy',
         'matplotlib',
         'panedr',
-        'gromacswrapper',
+        'gromacswrapper>=0.7',
         'tables',
         'typing',
         'scipy',


### PR DESCRIPTION
Remove Python type check in __init__;
Update a few old lines in energy_histo;
Fix a few unescaped backslashes in strings

This doesn't add any testing, unfortunately, but it does clarify the dependencies and should allow all functionality for all Python version >=2.7.14.

Fixes #35.