### PR TITLE
Revert "Possibly fix build issue"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 #
 MDAnalysis>=0.17.0
 pandas
-numpy>=1.16.0
+numpy
 matplotlib
 panedr
 py

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     install_requires=[
         'MDAnalysis>=0.17.0',
         'pandas',
-        'numpy>=1.16.0',
+        'numpy',
         'matplotlib',
         'panedr',
         'gromacswrapper>=0.7',


### PR DESCRIPTION
No longer need to specify NumPy version because of updated GSD build

See [GSD PR and related issue](https://github.com/glotzerlab/gsd/pull/24).

This reverts commit ce27661e1676d28466d89a887ccbfb79781acab7.